### PR TITLE
Allow specifying `json_library` other than `Jason`

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,7 @@
 import Config
 
+config :telegex, 
+  # Use Jason by default. Overridable by end-users.
+  json_library: Jason
+
 import_config "#{config_env()}.exs"

--- a/lib/mix/tasks/gen.doc_json.ex
+++ b/lib/mix/tasks/gen.doc_json.ex
@@ -197,10 +197,19 @@ if Mix.env() in [:dev, :test] do
 
       doc_map = %{types: all_types, union_types: all_union_types, methods: all_methods}
 
-      json = Jason.encode!(doc_map, pretty: true)
+      json = json_encode!(doc_map)
 
       Mix.Generator.create_file("priv/bot_api_doc.json", json, force: true)
     end
+
+    defp json_encode!(data, library \\ Application.fetch_env!(:telegex, :json_library))
+
+    # Both Jason and Poison support pretty-printing options
+    defp json_encode!(data, libarary) when libarary in [Jason, Poison],
+      do: libarary.encode!(data, pretty: true)
+
+    # For anything else (like built-in Elixir 1.18 JSON), let's stick to encode!/1
+    defp json_encode!(data, libarary), do: libarary.encode!(data)
 
     defp parse_sections(nodes, tag, i \\ 0, sections \\ []) do
       current = Enum.at(nodes, i)

--- a/lib/telegex/caller/adapter.ex
+++ b/lib/telegex/caller/adapter.ex
@@ -43,9 +43,15 @@ defmodule Telegex.Caller.Adapter do
 
   @spec struct_response(String.t() | map) :: Response.t()
   def struct_response(json) when is_binary(json) do
-    data = Jason.decode!(json, keys: :atoms)
+    json_library = Application.fetch_env!(:telegex, :json_library)
+    data = json_library.decode!(json)
 
-    struct(Response, data)
+    %Response{
+      ok: data["ok"],
+      result: data["result"],
+      error_code: data["error_code"],
+      description: data["description"]
+    }
   end
 
   def struct_response(%{ok: ok, error_code: error_code, description: description}) do

--- a/lib/telegex/caller/adapter/finch.ex
+++ b/lib/telegex/caller/adapter/finch.ex
@@ -19,7 +19,8 @@ defmodule Telegex.Caller.Adapter.Finch do
     build_args =
       case try_build_multipart(params, attachment_fields) do
         :none ->
-          json_body = params |> Enum.into(%{}) |> Jason.encode!()
+          json_library = Application.fetch_env!(:telegex, :json_library)
+          json_body = params |> Enum.into(%{}) |> json_library.encode!()
 
           [:post, url, [@json_header], json_body]
 
@@ -168,7 +169,8 @@ defmodule Telegex.Caller.Adapter.Finch do
     Enum.reduce(without_attachments_params, multipart, fn {key, value}, updated_multipart ->
       cond do
         is_map(value) or is_list(value) ->
-          add_part(updated_multipart, text_field_part(Jason.encode!(value), key))
+          json_library = Application.fetch_env!(:telegex, :json_library)
+          add_part(updated_multipart, text_field_part(json_library.encode!(value), key))
 
         is_binary(value) ->
           add_part(updated_multipart, text_field_part(value, key))

--- a/lib/telegex/caller/adapter/httpoison.ex
+++ b/lib/telegex/caller/adapter/httpoison.ex
@@ -9,7 +9,8 @@ defmodule Telegex.Caller.Adapter.HTTPoison do
   @impl true
   def call(method, params, opts) do
     url = build_url(method)
-    json_body = params |> Enum.into(%{}) |> Jason.encode!()
+    json_library = Application.fetch_env!(:telegex, :json_library)
+    json_body = params |> Enum.into(%{}) |> json_library.encode!()
 
     url |> request(json_body, opts) |> parse_response()
   end

--- a/lib/telegex/hook/server.ex
+++ b/lib/telegex/hook/server.ex
@@ -13,7 +13,11 @@ if Code.ensure_loaded?(Plug) do
     end
 
     plug :match
-    plug Plug.Parsers, parsers: [:json], json_decoder: {Jason, :decode!, [[keys: :atoms]]}
+
+    plug Plug.Parsers,
+      parsers: [:json],
+      json_decoder: {Application.compile_env!(:telegex, :json_library), :decode!, []}
+
     plug :dispatch
 
     require Logger
@@ -84,9 +88,11 @@ if Code.ensure_loaded?(Plug) do
     end
 
     defp resp_json(conn, map) do
+      json_library = Application.fetch_env!(:telegex, :json_library)
+
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(200, Jason.encode!(map))
+      |> send_resp(200, json_library.encode!(map))
     end
   end
 end

--- a/lib/telegex/type_definer.ex
+++ b/lib/telegex/type_definer.ex
@@ -155,10 +155,11 @@ defmodule Telegex.TypeDefiner do
         end
       end
 
+      # Define Jason.Encoder only Jason is available.
       if function_exported?(Jason, :__info__, 1) do
         # 自定义编码过程，去掉所有的 nil 字段
         # Even if the user sets json_library to something other than Jason, having
-        # this protocol implementation is harmless. 
+        # this protocol implementation is harmless.
         defimpl Jason.Encoder, for: __MODULE__.unquote(name) do
           def encode(struct, opts) do
             struct
@@ -170,9 +171,8 @@ defmodule Telegex.TypeDefiner do
         end
       end
 
+      # Define JSON.Encoder only if we are running on Elixir 1.18 (which defines JSON module)
       if function_exported?(JSON, :__info__, 1) do
-        # Even if the user isn't running on Elixir 1.18+, having this protocol 
-        # implementation is harmless.
         defimpl JSON.Encoder, for: __MODULE__.unquote(name) do
           def encode(struct, encoder) do
             struct

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,7 @@ defmodule Telegex.MixProject do
       {:bandit, "~> 1.5", optional: true, only: [:dev, :test]},
       {:floki, "~> 0.36.3", only: [:dev, :test]},
       {:typed_struct, "~> 0.3.0"},
-      {:jason, "~> 1.4"}
+      {:jason, "~> 1.4", optional: true}
     ]
   end
 

--- a/test/telegex/caller/adapter_test.exs
+++ b/test/telegex/caller/adapter_test.exs
@@ -15,7 +15,7 @@ defmodule Telegex.Caller.AdapterTest do
 
     r = call("getMe")
 
-    assert match?({:ok, %{is_bot: true}}, r)
+    assert match?({:ok, %{"is_bot" => true}}, r)
   end
 
   test "Adapter.HTTPoison error" do
@@ -31,7 +31,7 @@ defmodule Telegex.Caller.AdapterTest do
 
     r = call("getMe")
 
-    assert match?({:ok, %{is_bot: true}}, r)
+    assert match?({:ok, %{"is_bot" => true}}, r)
   end
 
   test "Adapter.Finch error" do

--- a/test/telegex/helper_test.exs
+++ b/test/telegex/helper_test.exs
@@ -10,12 +10,12 @@ defmodule Telegex.HelperTest do
   test "most_repeated_fields_type/2" do
     # 测试找出与数据有最多字段重复的具体类型
     map = %{
-      type: "audio",
-      id: 1_231_032_181,
-      audio_file_id: "CQACAgQAAxkBAAIBXV6ZQZ3Z33Z3Z3Z3Z3Z3Z3Z3Z3Z3AAEcBA",
-      caption: "test audio",
-      parse_mode: "MarkdownV2",
-      caption_entities: []
+      "type" => "audio",
+      "id" => 1_231_032_181,
+      "audio_file_id" => "CQACAgQAAxkBAAIBXV6ZQZ3Z33Z3Z3Z3Z3Z3Z3Z3Z3Z3AAEcBA",
+      "caption" => "test audio",
+      "parse_mode" => "MarkdownV2",
+      "caption_entities" => []
     }
 
     assert most_repeated_fields_type(map, [
@@ -24,9 +24,9 @@ defmodule Telegex.HelperTest do
            ]) == {0, Telegex.Type.InlineQueryResultCachedAudio}
 
     map = %{
-      message_id: 1001,
-      date: 101,
-      text: "Hello!"
+      "message_id" => 1001,
+      "date" => 101,
+      "text" => "Hello!"
     }
 
     assert most_repeated_fields_type(map, [:boolean, Telegex.Type.Message]) ==
@@ -41,7 +41,7 @@ defmodule Telegex.HelperTest do
     assert typedmap(1.25, :float) == 1.25
 
     # 测试数组类型
-    assert typedmap([%{update_id: 1}, %{update_id: 2}], %ArrayType{elem_type: Update}) ==
+    assert typedmap([%{"update_id" => 1}, %{"update_id" => 2}], %ArrayType{elem_type: Update}) ==
              [
                %Update{update_id: 1},
                %Update{update_id: 2}
@@ -51,9 +51,9 @@ defmodule Telegex.HelperTest do
     typed_data =
       typedmap(
         %{
-          message_id: 1001,
-          date: 101,
-          text: "Hello!"
+          "message_id" => 1001,
+          "date" => 101,
+          "text" => "Hello!"
         },
         %UnionType{types: [:boolean, Message]}
       )
@@ -65,25 +65,44 @@ defmodule Telegex.HelperTest do
     typed_data =
       typedmap(
         %{
-          status: "creator",
-          is_anonymous: false,
-          user: %{id: 1001, is_bot: true, first_name: "Bob"}
+          "status" => "creator",
+          "is_anonymous" => false,
+          "user" => %{"id" => 1001, "is_bot" => true, "first_name" => "Bob"}
         },
         Telegex.Type.ChatMember
       )
 
     # 测试联合类型模块（有基础相关性的联合类型）
     assert match?(%ChatMemberOwner{}, typed_data)
+
+    typed_data = typedmap(%{
+      "type" => "commands",
+      "text" => "Hello!",
+      "web_app" => %{
+        "url" => "https://example.com",
+      }
+    }, Telegex.Type.MenuButtonWebApp)
+
+    assert match?(%Telegex.Type.MenuButtonWebApp{
+      type: "commands",
+      text: "Hello!",
+      web_app: %Telegex.Type.WebAppInfo{
+        url: "https://example.com"
+      }
+    }, typed_data)
+
+    typed_data = typedmap(%{"type" => "default"}, Telegex.Type.MenuButton)
+    assert match?(%Telegex.Type.MenuButtonDefault{type: "default"}, typed_data)
   end
 
   test "warning" do
     # 测试最终类型的字段列表不能完全抵消返回的数据的字段列表
     fun = fn ->
       map = %{
-        unkown_field: :unkown_value,
-        message_id: 1001,
-        date: 101,
-        text: "Hello!"
+        "unkown_field" => :unkown_value,
+        "message_id" => 1001,
+        "date" => 101,
+        "text" => "Hello!"
       }
 
       typed_data = typedmap(map, %UnionType{types: [:boolean, Telegex.Type.Message]})
@@ -99,9 +118,9 @@ defmodule Telegex.HelperTest do
       typed_data =
         typedmap(
           %{
-            status: "unkown_value",
-            is_anonymous: false,
-            user: %{id: 1001, is_bot: true, first_name: "Bob"}
+            "status" => "unkown_value",
+            "is_anonymous" => false,
+            "user" => %{"id" => 1001, "is_bot" => true, "first_name" => "Bob"}
           },
           Telegex.Type.ChatMember
         )

--- a/test/telegex/method_test.exs
+++ b/test/telegex/method_test.exs
@@ -1,0 +1,17 @@
+defmodule Telegex.MethodTest do
+  use ExUnit.Case
+
+  # Test method invokations end-to-end
+  # Testing things other than get_me with the real Telegram servers is tricky,
+  # since we'd have to have at least two accounts to test sending messages, 
+  # checking for updates, etc.
+  test "get_me" do
+    Application.put_env(:telegex, :caller_adapter, Finch)
+
+    {:ok, user} = Telegex.get_me()
+    assert match?(%Telegex.Type.User{is_bot: true}, user)
+    assert is_integer(user.id)
+    assert is_binary(user.first_name)
+    assert is_binary(user.username)
+  end
+end


### PR DESCRIPTION
With the release of Elixir 1.18, there is a new built-in `JSON` module. It is largely based on `Jason` (same author), and when running on OTP 27, leverages newly made `:json` Erlang module.

I expect the larger community to standardize on `JSON` in the future, and move away from `Jason` and `Poison` in the future. I'd say less dependencies is good.

This PR allows customizing which json library to use via the `json_library` config option:
```elixir
import Config

config :telegex, :json_library, JSON # or Jason, or Poison, or maybe even :jiffy
```

Unfortunately it isn't as straightforward as just replacing `Jason.encode!`/`Jason.decode!` with the `JSON.enode!`/`JSON.decode!` counterparts.

Welp, for something like `Poison` it is, since they share similar options (`:pretty` and `:keys`).

Notably, `JSON` and `:jiffy` don't do `keys: :atoms`. Object keys are always strings. And that's for a good reason. Erlang VM has an upper limit on atoms. If user can supply arbitrary input, they can crash the VM. In our case it's isn't as big of a concern since the decoding either happens at built-time, or inputs are coming from a (hopefully trusted) third party — telegram.

Either way, I've made changes to how the responses are unmarshaled into the typed structs (`typedmap/2`). The input is now expected to be stringly-typed maps, instead of atoms.

The test are passing on `:json_library` set to `Jason` (the default), `Poison`, and 1.18's `JSON`. I wouldn't say I trust the test suite to be fair. There are a lot of unexercised end-to-end codepaths. There are still things I'm unsure of:
- I'm not sure webhooks are left intact.
- If the code at `caller/adapter.ex:65` is ever exercised, this implementation is likely to break (as `result` would likely have atom, not binary keys)
- This might be a breaking change, especially if custom caller adapters is something that's utilized in the wild (unknowable).

Also, I've added a couple of test cases to catch incorrect unmarshaling.