### PR TITLE
fix: guard webhook server on Plug.Router availability

### DIFF
--- a/lib/telegex/hook/server.ex
+++ b/lib/telegex/hook/server.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Plug) do
+if Code.ensure_loaded?(Plug.Router) do
   defmodule Telegex.Hook.Server do
     @moduledoc false
 


### PR DESCRIPTION
## Summary
- guard `Telegex.Hook.Server` compilation on `Plug.Router` rather than `Plug`
- avoid compile failures in consumers where `Plug` is present but `Plug.Router` isn't loaded in the dependency compile phase

## Why
Some downstream builds fail while compiling `telegex` with:

- `module Plug.Router is not loaded and could not be found`

This keeps webhook server optional while preserving current behavior when router support is available.

## Change
- `lib/telegex/hook/server.ex`
  - `if Code.ensure_loaded?(Plug)` -> `if Code.ensure_loaded?(Plug.Router)`
